### PR TITLE
Fix editUrl in docusaurus config

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -38,7 +38,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/psake/docs/blob/main/docs',
+            'https://github.com/psake/docs/blob/main',
         },
         blog: {
           showReadingTime: true,
@@ -49,7 +49,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/psake/docs/blob/main/blog',
+            'https://github.com/psake/docs/blob/main',
           // Useful options to enforce blogging best practices
           onInlineTags: 'warn',
           onInlineAuthors: 'warn',


### PR DESCRIPTION
After having a quick look at the new site, I saw that the links to edit both the docs and blog section were taking me over to a 404 in the GitHub repository. There was an extra "docs" and "blog" in the URLs that were being used.

I actually have no idea whether this change will work, but based on what I am seeing being generated, it would appear to make sense.