### PR TITLE
Properties: Fix Codeblock Title

### DIFF
--- a/.frontmatter/database/mediaDb.json
+++ b/.frontmatter/database/mediaDb.json
@@ -1,1 +1,10 @@
-{"static":{"img":{}}}
+{
+  "static": {
+    "img": {}
+  },
+  "docs": {
+    "static": {
+      "img": {}
+    }
+  }
+}

--- a/.frontmatter/database/taxonomyDb.json
+++ b/.frontmatter/database/taxonomyDb.json
@@ -1,1 +1,6 @@
-{}
+{
+  "taxonomy": {
+    "tags": [],
+    "categories": []
+  }
+}

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,27 +1,4 @@
-yangshun:
-  name: Yangshun Tay
-  title: Front End Engineer @ Facebook
-  url: https://github.com/yangshun
-  image_url: https://github.com/yangshun.png
-  page: true
-  socials:
-    x: yangshunz
-    github: yangshun
-
-slorber:
-  name: Sébastien Lorber
-  title: Docusaurus maintainer
-  url: https://sebastienlorber.com
-  image_url: https://github.com/slorber.png
-  page:
-    # customize the url of the author page at /blog/authors/<permalink>
-    permalink: '/all-sebastien-lorber-articles'
-  socials:
-    x: sebastienlorber
-    linkedin: sebastienlorber
-    github: slorber
-    newsletter: https://thisweekinreact.com
-
+# https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-blog#authors-file
 heyitsgilbert:
   name: Gilbert Sanchez
   title: Core Contributor

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -1,4 +1,7 @@
-# Contributor Covenant Code of Conduct
+---
+title: Contributor Covenant Code of Conduct
+description: Learn how we expect our community members to conduct themselves.
+---
 
 ## Our Pledge
 
@@ -39,7 +42,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at coc@psake.dev. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <coc@psake.dev>. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
@@ -74,11 +77,11 @@ Community leaders will follow these Community Impact Guidelines in determining t
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0,
-available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+available at <https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
+<https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -5,19 +5,28 @@ description: Learn how we expect our community members to conduct themselves.
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
 
-We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to a positive environment for our community include:
+Examples of behavior that contributes to a positive environment for our
+community include:
 
 * Demonstrating empathy and kindness toward other people
 * Being respectful of differing opinions, viewpoints, and experiences
 * Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall community
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
 
 Examples of unacceptable behavior include:
 
@@ -32,56 +41,95 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <coc@psake.dev>. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[coc@psake.dev](mailto:coc@psake.dev). All complaints will be reviewed and
+investigated promptly and fairly.
 
-All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
 
 ## Enforcement Guidelines
 
-Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
 
-**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
 
-**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series of actions.
+**Community Impact**: A violation through a single incident or series of
+actions.
 
-**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
 
 ### 3. Temporary Ban
 
-**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
 
-**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
 
-**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within the project community.
+**Consequence**: A permanent ban from any sort of public interaction within the
+project community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0,
-available at <https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
-
-[homepage]: https://www.contributor-covenant.org
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
 
 For answers to common questions about this code of conduct, see the FAQ at
-<https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/docs/tutorial-basics/parameters-properties.md
+++ b/docs/tutorial-basics/parameters-properties.md
@@ -8,10 +8,10 @@ sidebar_position: 11
 To summarize the differences between passing parameters and properties to the
 `Invoke-psake` function:
 
-* Parameters and "properties" can both be passed to the Invoke-psake function
+* Parameters and Properties can both be passed to the Invoke-psake function
   simultaneously
-* Parameters are set before any "properties" blocks are run
-* Properties are set after all "properties" blocks have run
+* Parameters are set before any `properties` blocks are run
+* Properties are set after all `properties` blocks have run
 
 ## Parameters
 
@@ -22,12 +22,17 @@ the Invoke-psake function. The following is an example:
 Invoke-psake .\parameters.ps1 -parameters @{"p1"="v1";"p2"="v2"}
 ```
 
-The example above runs the build script called "parameters.ps1" and passes in
-parameters 'p1' and 'p2' with values 'v1' and 'v2'. The parameter value for the
+The example above runs the build script called `parameters.ps1` and passes in
+parameters `p1` and `p2` with values `v1` and `v2`. The parameter value for the
 "parameters" parameter (say that 10 times really fast!) is a PowerShell
-hashtable where the name and value of each parameter is specified. Note: You
-don't need to use the "$" character when specifying the parameter names in the
-hashtable.
+hashtable where the name and value of each parameter is specified.
+
+:::note
+
+You don't need to use the "$" character when specifying the parameter names in
+the hashtable.
+
+:::
 
 ```powershell title="parameters.ps1"
 properties {
@@ -41,6 +46,9 @@ task TestParams {
 }
 ```
 
+The Assert in this example would pass because when it runs, `$my_property`
+would be set to `v1v2` and not be `$null`.
+
 ## Properties
 
 You can override a property in your build script using the `properties`
@@ -50,11 +58,17 @@ parameter of the Invoke-psake function. The following is an example:
 Invoke-psake .\properties.ps1 -properties @{"x"="1";"y"="2"}
 ```
 
-The example above runs the build script called "properties.ps1" and passes in
-parameters 'x' and 'y' with values '1' and '2'. The parameter value for the
+The example above runs the build script called `properties.ps1` and passes in
+parameters `x` and `y` with values `1` and `2`. The parameter value for the
 "properties" parameter is a PowerShell hashtable where the name and value of
-each property is specified. Note: You don't need to use the "$" character when
-specifying the property names in the hashtable.
+each property is specified.
+
+:::note
+
+You don't need to use the "$" character when specifying the property names in
+the hashtable.
+
+:::
 
 ```powershell title="properties.ps1"
 properties {

--- a/docs/tutorial-basics/parameters-properties.md
+++ b/docs/tutorial-basics/parameters-properties.md
@@ -1,17 +1,16 @@
 ---
+title: Parameters & Properties
 description: "How to use parameters and properties in your build script."
 sidebar_position: 11
 ---
 
-# Parameters & Properties
-
 To summarize the differences between passing parameters and properties to the
 `Invoke-psake` function:
 
-* Parameters and Properties can both be passed to the Invoke-psake function
+* Parameters and "properties" can both be passed to the Invoke-psake function
   simultaneously
-* Parameters are set before any `properties` blocks are run
-* Properties are set after all `properties` blocks have run
+* Parameters are set before any "properties" blocks are run
+* Properties are set after all "properties" blocks have run
 
 ## Parameters
 

--- a/docs/tutorial-basics/parameters-properties.md
+++ b/docs/tutorial-basics/parameters-properties.md
@@ -56,9 +56,7 @@ parameters 'x' and 'y' with values '1' and '2'. The parameter value for the
 each property is specified. Note: You don't need to use the "$" character when
 specifying the property names in the hashtable.
 
-The "properties.ps1" build script looks like this:
-
-```powershell
+```powershell title="properties.ps1"
 properties {
  $x = $null
  $y = $null

--- a/docs/tutorial-basics/parameters-properties.md
+++ b/docs/tutorial-basics/parameters-properties.md
@@ -87,5 +87,5 @@ task TestProperties {
 ```
 
 The value of `$x` should be `1` and `$y` should be `2` by the time the
-`TestProperties` task is executed. The value of `$z` was not over-ridden so it
+`TestProperties` task is executed. The value of `$z` was not overridden so it
 should still be `$null`.

--- a/docs/tutorial-basics/parameters-properties.md
+++ b/docs/tutorial-basics/parameters-properties.md
@@ -86,6 +86,6 @@ task TestProperties {
 }
 ```
 
-The value of $x should be 1 and $y should be 2 by the time the "TestProperties"
-task is executed. The value of $z was not over-ridden so it should still be
-$null.
+The value of `$x` should be `1` and `$y` should be `2` by the time the
+`TestProperties` task is executed. The value of `$z` was not over-ridden so it
+should still be `$null`.

--- a/docs/tutorial-basics/tasks.md
+++ b/docs/tutorial-basics/tasks.md
@@ -1,7 +1,7 @@
 ---
-sidebar_position: 4
+title: Tasks
+description: "Learn how to use the most important building block in psake: The Task"
 ---
-# Tasks
 
 At the core of psake is the task. In it's simplest form you have a task with a
 name and an action.

--- a/frontmatter.json
+++ b/frontmatter.json
@@ -66,6 +66,138 @@
     {
       "title": "docs",
       "path": "[[workspace]]/docs"
+    },
+    {
+      "title": "commands",
+      "path": "[[workspace]]/docs/commands"
     }
-  ]
+  ],
+  "frontMatter.content.snippets": {
+    "MDX: Code Snippet": {
+      "description": "Markdown 'code' template\"",
+      "body": [
+        "```[[language]] title='[[title]]'",
+        "",
+        "```"
+      ],
+      "fields": [
+        {
+          "name": "language",
+          "title": "language",
+          "type": "choice",
+          "single": true,
+          "default": "powershell",
+          "choices": [
+            "bash",
+            "c",
+            "clike",
+            "coffeescript",
+            "cpp",
+            "css",
+            "diff",
+            "git",
+            "go",
+            "graphql",
+            "handlebars",
+            "javascript",
+            "json",
+            "jsx",
+            "less",
+            "makefile",
+            "markdown",
+            "markup",
+            "objectivec",
+            "ocaml",
+            "powershell",
+            "python",
+            "reason",
+            "sass",
+            "scss",
+            "sql",
+            "stylus",
+            "tsx",
+            "typescript",
+            "wasm",
+            "yaml"
+          ]
+        },
+        {
+          "name": "title",
+          "title": "title",
+          "type": "string",
+          "single": true,
+          "default": ""
+        }
+      ]
+    },
+    "Markdown Image Snippet": {
+      "body": "![[[&caption]]]([[&mediaUrl]] [[&title]])",
+      "description": "",
+      "isMediaSnippet": true
+    },
+    "Markdown Frontmatter Sidebar Snippet": {
+      "body": [
+        "---",
+        "sidebar_label: [[sidebar_label]]",
+        "sidebar_position: [[sidebar_position]]",
+        "---"
+      ],
+      "description": "",
+      "fields": [
+        {
+          "name": "sidebar_label",
+          "title": "sidebar_label",
+          "type": "string",
+          "single": true,
+          "default": ""
+        },
+        {
+          "name": "sidebar_position",
+          "title": "sidebar_position",
+          "type": "string",
+          "single": true,
+          "default": ""
+        }
+      ]
+    },
+    "Markdown Admonitions": {
+      "body": [
+        ":::[[type]] [[title]]",
+        "[[selection]]",
+        ":::"
+      ],
+      "description": "Markdown 'admonition' template.",
+      "fields": [
+        {
+          "name": "type",
+          "title": "type",
+          "type": "choice",
+          "single": true,
+          "default": "note",
+          "choices": [
+            "note",
+            "tip",
+            "info",
+            "caution",
+            "danger"
+          ]
+        },
+        {
+          "name": "title",
+          "title": "title",
+          "type": "string",
+          "single": true,
+          "default": ""
+        },
+        {
+          "name": "selection",
+          "title": "selection",
+          "type": "string",
+          "single": true,
+          "default": "FM_SELECTED_TEXT"
+        }
+      ]
+    }
+  },
+  "frontMatter.website.host": "https://psake.dev"
 }


### PR DESCRIPTION
1. Remove old images
2. Move doc titles into frontmatter.
3. Delete dupe doc `parameters`
4. Add some frontmatter snippets.
5. Properties: The codeblock is referred to as a file. We have title support so we should just use that.
6. Code of Conduct: Fix links