### PR TITLE
Fix build script filename typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ support versioned docs.
 ## Installation
 
 ```powershell
-.\builds.ps1 -Bootstrap
+.\build.ps1 -Bootstrap
 ```
 
 ## Local Development
 
 ```powershell
-.\build.ps1 -Task Server 
+.\build.ps1 -Task Server
 ```
 
 This command starts a local development server and opens up a browser window.


### PR DESCRIPTION
## Summary
- Fixes typo in README: `builds.ps1` → `build.ps1` (matching the actual script name)
- Removes trailing whitespace

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)