### PR TITLE
Fix build-breaking bugs in psakeFile.ps1

### DIFF
--- a/psakeFile.ps1
+++ b/psakeFile.ps1
@@ -108,7 +108,7 @@ Task -Name "GenerateCommandReference-Gen" -Depends 'GenerateCommandReference-Cle
   Get-ChildItem $script:docsOutputFolder | ForEach-Object {
     $path = $_.FullName
     Write-Host "Fixing relative links for: $path"
-    Get-Content $path | ForEach-Object {
+    (Get-Content $path) | ForEach-Object {
       $_ -replace "\[(.+)\]\(\)", '[$1]($1.mdx)'
     } | Set-Content $path
   }
@@ -136,7 +136,7 @@ Task -Name 'FrontMatterCMSSync' {
     $yaml = Get-Content -Raw $_ | ConvertFrom-Yaml
     foreach ($item in $yaml.Keys) {
       $value = $yaml[$item]
-      if (-not $value.ContainsKey('handle')) {
+      if (-not $value.Contains('handle')) {
         $value.Add('handle', $item)
       }
       $output += $value


### PR DESCRIPTION
## Summary
- Wrap `Get-Content` in parentheses to prevent file lock conflict when reading and writing the same file in a pipeline (line 111)
- Use `.Contains()` instead of `.ContainsKey()` for `OrderedDictionary` returned by `ConvertFrom-Yaml` (line 139)

## Test plan
- [ ] Run `pwsh -Command "./build.ps1 -Bootstrap"` and verify it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)