### PR TITLE
Add prerequisites section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ support versioned docs.
 
 - [Node.js](https://nodejs.org/) >= 18.0
 - [Yarn](https://classic.yarnpkg.com/) (`npm install -g yarn`)
-- [PowerShell 7+](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell) (`pwsh`)
+- [PowerShell 7+](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell) (run `pwsh`)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern
 static website generator. The main feature for us was it's ability to
 support versioned docs.
 
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) >= 18.0
+- [Yarn](https://classic.yarnpkg.com/) (`npm install -g yarn`)
+- [PowerShell 7+](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell) (`pwsh`)
+
 ## Installation
 
 ```powershell


### PR DESCRIPTION
## Summary
- Add a Prerequisites section listing Node.js >= 18, Yarn, and PowerShell 7+ with install links
- Helps contributors avoid setup issues when running `.\build.ps1 -Bootstrap` for the first time

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)