### PR TITLE
Fix mobile hero layout: prevent grid overflow from CodeBlock min-content width

### DIFF
--- a/src/components/CodeShowcase/styles.module.css
+++ b/src/components/CodeShowcase/styles.module.css
@@ -86,7 +86,7 @@
 
 @media screen and (max-width: 996px) {
   .codeOutputGrid {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
@@ -96,6 +96,7 @@
   border-radius: 8px;
   overflow: hidden;
   border: 1px solid var(--ifm-color-emphasis-200);
+  min-width: 0;
 }
 
 [data-theme='dark'] .codeBlock,

--- a/src/components/FeatureGrid/styles.module.css
+++ b/src/components/FeatureGrid/styles.module.css
@@ -35,6 +35,8 @@
   display: flex;
   flex-direction: column;
   animation: fadeInUp 0.6s ease-out backwards;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .featureCard:nth-child(1) { animation-delay: 0.05s; }
@@ -89,6 +91,7 @@
   padding: 0.75rem !important;
   background: var(--ifm-color-emphasis-100) !important;
   border-radius: 6px;
+  overflow-x: auto !important;
 }
 
 [data-theme='dark'] .featureCode pre {
@@ -116,7 +119,7 @@
   }
 
   .grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     gap: 1.5rem;
   }
 

--- a/src/components/HeroCodePreview/styles.module.css
+++ b/src/components/HeroCodePreview/styles.module.css
@@ -65,6 +65,7 @@
   padding: 0;
   max-height: 400px;
   overflow-y: auto;
+  overflow-x: auto;
 }
 
 .codeWrapper pre {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -35,6 +35,11 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Prevent horizontal overflow on mobile */
+body {
+  overflow-x: hidden;
+}
+
 /* Enhanced button styles */
 .button {
   font-weight: 600;

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -123,7 +123,7 @@
   }
 
   .heroContent {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     gap: 3rem;
     min-height: auto;
   }


### PR DESCRIPTION
CSS Grid's `1fr` resolves to `minmax(auto, 1fr)`, so the single-column grid
at mobile would expand to match the CodeBlock's intrinsic min-content width
(long pre lines with white-space:pre). This pushed the grid wider than the
viewport, causing centered hero content to appear shifted right and clipped.

- Change grid-template-columns to minmax(0, 1fr) so the column can shrink
  to viewport width at mobile breakpoints
- Add overflow-x: auto to .codeWrapper so code scrolls internally instead
  of forcing the layout wider

https://claude.ai/code/session_011EoMBuj77i4k8YNFyye1zM