### PR TITLE
Add Inter, Maven Pro, and JetBrains Mono font stack

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,7 +6,7 @@
 
 /* Fonts: Roboto (display/headings) · Inter (body/UI) · JetBrains Mono (code)
  * Single request loads all three families; display=swap avoids FOIT. */
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Montserrat:wght@500;700;900&family=JetBrains+Mono:wght@400;500;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Maven+Pro:wght@500;700;900&family=JetBrains+Mono:wght@400;500;700&display=swap");
 
 /* Color is charcoal */
 :root {
@@ -22,7 +22,7 @@
   /* Type system */
   --ifm-font-family-base: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --ifm-font-family-monospace: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
-  --ifm-heading-font-family: "Montserrat", system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  --ifm-heading-font-family: "Maven Pro", system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,7 +6,7 @@
 
 /* Fonts: Roboto (display/headings) · Inter (body/UI) · JetBrains Mono (code)
  * Single request loads all three families; display=swap avoids FOIT. */
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto:wght@500;700;900&family=JetBrains+Mono:wght@400;500;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Montserrat:wght@500;700;900&family=JetBrains+Mono:wght@400;500;700&display=swap");
 
 /* Color is charcoal */
 :root {
@@ -22,7 +22,7 @@
   /* Type system */
   --ifm-font-family-base: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --ifm-font-family-monospace: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
-  --ifm-heading-font-family: "Roboto", system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  --ifm-heading-font-family: "Montserrat", system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -4,6 +4,10 @@
  * work well for content-centric websites.
  */
 
+/* Fonts: Roboto (display/headings) · Inter (body/UI) · JetBrains Mono (code)
+ * Single request loads all three families; display=swap avoids FOIT. */
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto:wght@500;700;900&family=JetBrains+Mono:wght@400;500;700&display=swap");
+
 /* Color is charcoal */
 :root {
   --ifm-color-primary: #2a6b32;
@@ -15,6 +19,10 @@
   --ifm-color-primary-lightest: #35863e;
   --ifm-background-color: #F8F9F5;
   --ifm-code-font-size: 95%;
+  /* Type system */
+  --ifm-font-family-base: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --ifm-font-family-monospace: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
+  --ifm-heading-font-family: "Roboto", system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 


### PR DESCRIPTION
## Summary

- Adds a single Google Fonts `@import` loading Inter, Roboto, and JetBrains Mono in one request (`display=swap` avoids FOIT)
- Sets Infima CSS variables: `--ifm-font-family-base` (Inter), `--ifm-heading-font-family` (Roboto), `--ifm-font-family-monospace` (JetBrains Mono)
- Roboto loaded at weights 500/700/900 to support hero titles (Black 900) and section headings (Bold 700)

## Test plan

- [ ] Run `bun start` and verify body text renders in Inter
- [ ] Verify headings (`h1`–`h3`) render in Roboto
- [ ] Verify code blocks render in JetBrains Mono
- [ ] Check dark mode — font variables are inherited, no separate dark override needed
- [ ] Run `.\build.ps1 -Task Test` to confirm no broken links introduced

https://claude.ai/code/session_016imc14aFL2PYqA4qpUK9Dh

---
_Generated by [Claude Code](https://claude.ai/code/session_016imc14aFL2PYqA4qpUK9Dh)_